### PR TITLE
Implement strict keywords protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ default:
         Chekote\BehatRetryExtension:
           timeout: 10
           interval: 1000000000
+          strict-keywords: true
 ```
 
 ## Configuration Options
@@ -57,6 +58,22 @@ Default: 100000000 (0.1 seconds)
 The interval is how many nanoseconds the extension will wait between attempts. The default is to attempt 10 times a second. Attempting the retry more frequently will potentially allow your tests to pass quicker, but this depends on your environment.
 
 It is possible that attempting the assertion too frequently will put a load on your application in such a way that the tests actually take longer to run. You will need to experiment with your particular application to determine what setting is best for you.
+
+### Strict Keywords
+
+Type: Boolean
+
+Default: true
+
+When enabled, the Strict Keywords setting will only allow a step definition to be invoked if the correct keyword is used. For example, you cannot invoke a step definition of "Then I should see..." by using "Given I should see..." or "When I should see...". Note that when using "And" or "But", the extension will understand the context and consider these to be the same as the previous keyword. For example, the following "But" would be considered a "Then" as far as this extension is concerned:
+
+```gherkin
+Given I visit "/home"
+Then I should see "Welcome"
+But I should not see "Logout"
+```
+
+This setting defaults to true and it is highly recommended that you do not disable it. If this feature is disabled, it will allow a developer to use "Then" to invoke a non-Then step, causing the extension to spin a "Given" or a "When". Equally problematic, disabling this feature will allow a developer to use a "Given" or "When" to invoke a "Then", preventing the extension from spinning the "Then" step.
 
 ## Development
 

--- a/features/strict-keywords.feature
+++ b/features/strict-keywords.feature
@@ -26,7 +26,133 @@ Feature: Require that Gherkin keyword matches to invoke step definition
         }
         """
 
-  Scenario: Scenario fails if wrong keyword is used when strict keywords is enabled
+  Scenario: Scenario fails if the wrong keyword is used for "Given" step when strict keywords is enabled
+    Given a Behat configuration containing:
+        """
+        default:
+          extensions:
+            Chekote\BehatRetryExtension:
+              strictKeywords: true
+        """
+    And a feature file "features/passing_scenario.feature" containing:
+        """
+        Feature: Some Random Feature
+
+          Scenario: Test the feature
+            When the system has some state
+        """
+    When I run Behat
+    Then it should fail with "Step 'the system has some state' was matched but the wrong keyword 'When' was used. The step should be invoked with 'Given'"
+
+  Scenario Outline: Scenario fails if "And" or "But" is used to "inherit" the wrong keyword for "Given" step when strict keywords is enabled
+    Given a Behat configuration containing:
+        """
+        default:
+          extensions:
+            Chekote\BehatRetryExtension:
+              strictKeywords: true
+        """
+    And a feature file "features/passing_scenario.feature" containing:
+        """
+        Feature: Some Random Feature
+
+          Scenario: Test the feature
+            When I perform some action
+            <keyword> the system has some state
+        """
+    When I run Behat
+    Then it should fail with "Step 'the system has some state' was matched but the wrong keyword 'When' was used. The step should be invoked with 'Given'"
+
+    Examples:
+      | keyword |
+      | And     |
+      | But     |
+
+  Scenario: Scenario fails if wrong keyword is used for "When" step when strict keywords is enabled
+    Given a Behat configuration containing:
+        """
+        default:
+          extensions:
+            Chekote\BehatRetryExtension:
+              strictKeywords: true
+        """
+    And a feature file "features/passing_scenario.feature" containing:
+        """
+        Feature: Some Random Feature
+
+          Scenario: Test the feature
+            Given I perform some action
+        """
+    When I run Behat
+    Then it should fail with "Step 'I perform some action' was matched but the wrong keyword 'Given' was used. The step should be invoked with 'When'"
+
+  Scenario Outline: Scenario fails if "And" is used to "inherit" wrong keyword for When step when strict keywords is enabled
+    Given a Behat configuration containing:
+        """
+        default:
+          extensions:
+            Chekote\BehatRetryExtension:
+              strictKeywords: true
+        """
+    And a feature file "features/passing_scenario.feature" containing:
+        """
+        Feature: Some Random Feature
+
+          Scenario: Test the feature
+            Given the system has some state
+            <keyword> I perform some action
+        """
+    When I run Behat
+    Then it should fail with "Step 'I perform some action' was matched but the wrong keyword 'Given' was used. The step should be invoked with 'When'"
+
+    Examples:
+      | keyword |
+      | And     |
+      | But     |
+
+  Scenario: Scenario fails if wrong keyword is used for "Then" step when strict keywords is enabled
+    Given a Behat configuration containing:
+        """
+        default:
+          extensions:
+            Chekote\BehatRetryExtension:
+              strictKeywords: true
+        """
+    And a feature file "features/passing_scenario.feature" containing:
+        """
+        Feature: Some Random Feature
+
+          Scenario: Test the feature
+            When I assert something
+        """
+    When I run Behat
+    Then it should fail with "Step 'I assert something' was matched but the wrong keyword 'When' was used. The step should be invoked with 'Then'"
+
+  Scenario Outline: Scenario fails if "And" or "But" is used to "inherit" wrong keyword for "Then" step when strict keywords is enabled
+    Given a Behat configuration containing:
+        """
+        default:
+          extensions:
+            Chekote\BehatRetryExtension:
+              strictKeywords: true
+        """
+    And a feature file "features/passing_scenario.feature" containing:
+        """
+        Feature: Some Random Feature
+
+          Scenario: Test the feature
+            When I perform some action
+            <keyword> I assert something
+        """
+    When I run Behat
+    Then it should fail with "Step 'I assert something' was matched but the wrong keyword 'When' was used. The step should be invoked with 'Then'"
+
+    Examples:
+      | keyword |
+      | And     |
+      | But     |
+
+  Scenario: Scenario passes if correct keyword is used when strict keywords is enabled
     Given a Behat configuration containing:
         """
         default:
@@ -41,10 +167,42 @@ Feature: Require that Gherkin keyword matches to invoke step definition
           Scenario: Test the feature
             Given the system has some state
             When I perform some action
-            And I assert something
+            Then I assert something
         """
     When I run Behat
-    Then it should fail with "Step 'I assert something' was matched but the wrong keyword 'When' was used. The step should be invoked with 'Then'"
+    Then it should pass
+
+  Scenario: Scenario passes if "And" or "But" is used to "inherit" keyword when strict keywords is enabled
+    Given a Behat configuration containing:
+        """
+        default:
+          extensions:
+            Chekote\BehatRetryExtension:
+              strictKeywords: true
+        """
+    And a feature file "features/passing_scenario.feature" containing:
+        """
+        Feature: Some Random Feature
+
+          Scenario: Test the feature
+            Given the system has some state
+              And the system has some state
+              But the system has some state
+              And the system has some state
+              But the system has some state
+             When I perform some action
+              And I perform some action
+              But I perform some action
+              And I perform some action
+              But I perform some action
+             Then I assert something
+              And I assert something
+              But I assert something
+              And I assert something
+              But I assert something
+        """
+    When I run Behat
+    Then it should pass
 
   Scenario: Scenario passes if wrong keyword is used when strict keywords is disabled
     Given a Behat configuration containing:
@@ -59,9 +217,9 @@ Feature: Require that Gherkin keyword matches to invoke step definition
         Feature: Some Random Feature
 
           Scenario: Test the feature
-            Given the system has some state
-            When I perform some action
-            And I assert something
+            When the system has some state
+            Then I perform some action
+            Given I assert something
         """
     When I run Behat
     Then it should pass

--- a/features/strict-keywords.feature
+++ b/features/strict-keywords.feature
@@ -1,0 +1,67 @@
+Feature: Require that Gherkin keyword matches to invoke step definition
+  In order to ensure I am using the correct step definition
+  As a Behat developer
+  The test should fail when I use the wrong Gherkin keyword to invoke a step definition
+
+  Background:
+    Given a context file "features/bootstrap/FeatureContext.php" containing:
+        """
+        <?php
+
+        use Behat\Behat\Context\Context;
+
+        /**
+         * Context for definition keywords.
+         */
+        class FeatureContext implements Context
+        {
+            /** @Given the system has some state */
+            public function ensureSomething(): void {}
+
+            /** @When I perform some action */
+            public function doSomething(): void {}
+
+            /** @Then I assert something */
+            public function assertSomething(): void { }
+        }
+        """
+
+  Scenario: Scenario fails if wrong keyword is used when strict keywords is enabled
+    Given a Behat configuration containing:
+        """
+        default:
+          extensions:
+            Chekote\BehatRetryExtension:
+              strictKeywords: true
+        """
+    And a feature file "features/passing_scenario.feature" containing:
+        """
+        Feature: Some Random Feature
+
+          Scenario: Test the feature
+            Given the system has some state
+            When I perform some action
+            And I assert something
+        """
+    When I run Behat
+    Then it should fail with "Step 'I assert something' was matched but the wrong keyword 'When' was used. The step should be invoked with 'Then'"
+
+  Scenario: Scenario passes if wrong keyword is used when strict keywords is disabled
+    Given a Behat configuration containing:
+        """
+        default:
+          extensions:
+            Chekote\BehatRetryExtension:
+              strictKeywords: false
+        """
+    And a feature file "features/passing_scenario.feature" containing:
+        """
+        Feature: Some Random Feature
+
+          Scenario: Test the feature
+            Given the system has some state
+            When I perform some action
+            And I assert something
+        """
+    When I run Behat
+    Then it should pass

--- a/src/Chekote/BehatRetryExtension/Context/BehatRetryContext.php
+++ b/src/Chekote/BehatRetryExtension/Context/BehatRetryContext.php
@@ -14,6 +14,9 @@ class BehatRetryContext implements Context
     /** @var int the interval setting for RuntimeStepTester before a Scenario is ran */
     protected $originalInterval;
 
+    /** @var bool the strict keywords setting for RuntimeStepTester before a Scenario is ran */
+    protected $originalStrictKeywords;
+
     /**
      * Sets the number of seconds that an assertion (Then step) should retry before failing.
      *
@@ -37,6 +40,26 @@ class BehatRetryContext implements Context
     }
 
     /**
+     * Requires that steps should only match when the correct keyword is used.
+     *
+     * @Given strict keywords are required
+     */
+    public function enableStrictKeywords()
+    {
+        RuntimeStepTester::$strictKeywords = true;
+    }
+
+    /**
+     * Allows steps to match if if the correct keyword is not used.
+     *
+     * @Given strict keywords are not required
+     */
+    public function disableStrictKeywords()
+    {
+        RuntimeStepTester::$strictKeywords = false;
+    }
+
+    /**
      * Records the configuration of the RuntimeStepTester.
      *
      * The config is recorded so that it can be modified after the Scenario has ran, thus ensuring that config settings
@@ -48,6 +71,7 @@ class BehatRetryContext implements Context
     {
         $this->originalTimeout = RuntimeStepTester::$timeout;
         $this->originalInterval = RuntimeStepTester::$interval;
+        $this->originalStrictKeywords = RuntimeStepTester::$strictKeywords;
     }
 
     /**
@@ -61,5 +85,6 @@ class BehatRetryContext implements Context
     {
         $this->setTimeout($this->originalTimeout);
         $this->setInterval($this->originalInterval);
+        $this->originalStrictKeywords ? $this->enableStrictKeywords() : $this->disableStrictKeywords();
     }
 }

--- a/src/Chekote/BehatRetryExtension/Definition/Exception/StrictKeywordException.php
+++ b/src/Chekote/BehatRetryExtension/Definition/Exception/StrictKeywordException.php
@@ -1,0 +1,29 @@
+<?php namespace Chekote\BehatRetryExtension\Definition\Exception;
+
+use Behat\Behat\Definition\Definition;
+use Behat\Behat\Definition\Exception\SearchException;
+use RuntimeException;
+
+/**
+ * Represents an exception caused by an incorrect keyword used to invoke a step definition.
+ */
+final class StrictKeywordException extends RuntimeException implements SearchException
+{
+    /**
+     * Initializes strict keyword exception.
+     *
+     * @param string     $keyword    the keyword that was used to invoke the step.
+     * @param Definition $definition the definition that matched the step.
+     */
+    public function __construct($keyword, Definition $definition)
+    {
+        parent::__construct(
+            sprintf(
+                "Step '%s' was matched but the wrong keyword '%s' was used. The step should be invoked with '%s'",
+                $definition->getPattern(),
+                $keyword,
+                $definition->getType()
+            )
+        );
+    }
+}

--- a/src/Chekote/BehatRetryExtension/ServiceContainer/BehatRetryExtension.php
+++ b/src/Chekote/BehatRetryExtension/ServiceContainer/BehatRetryExtension.php
@@ -23,10 +23,12 @@ class BehatRetryExtension implements Extension
     const CONFIG_PARAM_ALL = 'parameters';
     const CONFIG_PARAM_INTERVAL = 'interval';
     const CONFIG_PARAM_TIMEOUT = 'timeout';
+    const CONFIG_PARAM_STRICT_KEYWORDS = 'strictKeywords';
 
     const CONFIG_ALL = self::CONFIG_KEY . '.' . self::CONFIG_PARAM_ALL;
     const CONFIG_RETRY_INTERVAL = self::CONFIG_KEY . '.' . self::CONFIG_PARAM_INTERVAL;
     const CONFIG_TIMEOUT = self::CONFIG_KEY . '.' . self::CONFIG_PARAM_TIMEOUT;
+    const CONFIG_STRICT_KEYWORDS = self::CONFIG_KEY . '.' . self::CONFIG_PARAM_STRICT_KEYWORDS;
 
     /**
      * {@inheritdoc}
@@ -66,6 +68,7 @@ class BehatRetryExtension implements Extension
             ->children()
                 ->floatNode(self::CONFIG_PARAM_TIMEOUT)->defaultValue(5)->end()
                 ->integerNode(self::CONFIG_PARAM_INTERVAL)->defaultValue(100000000)->end()
+                ->booleanNode(self::CONFIG_PARAM_STRICT_KEYWORDS)->defaultTrue()->end()
             ->end()
         ->end();
     }
@@ -78,6 +81,7 @@ class BehatRetryExtension implements Extension
         $container->setParameter(self::CONFIG_ALL, $config);
         $container->setParameter(self::CONFIG_TIMEOUT, $config[self::CONFIG_PARAM_TIMEOUT]);
         $container->setParameter(self::CONFIG_RETRY_INTERVAL, $config[self::CONFIG_PARAM_INTERVAL]);
+        $container->setParameter(self::CONFIG_STRICT_KEYWORDS, $config[self::CONFIG_PARAM_STRICT_KEYWORDS]);
 
         $this->loadRuntimeStepTester($container);
     }
@@ -93,5 +97,6 @@ class BehatRetryExtension implements Extension
     {
         RuntimeStepTester::$timeout = $container->getParameter(self::CONFIG_TIMEOUT);
         RuntimeStepTester::$interval = $container->getParameter(self::CONFIG_RETRY_INTERVAL);
+        RuntimeStepTester::$strictKeywords = $container->getParameter(self::CONFIG_STRICT_KEYWORDS);
     }
 }


### PR DESCRIPTION
When enabled, the Strict Keywords setting will only allow a step definition to be invoked if the correct keyword is used. For example, you cannot invoke a step definition of "Then I should see..." by using "Given I should see..." or "When I should see...". Note that when using "And" or "But", the extension will understand the context and consider these to be the same as the previous keyword. For example, the following "But" would be considered a "Then" as far as this extension is concerned:

```gherkin
Given I visit "/home"
Then I should see "Welcome"
But I should not see "Logout"
```

This setting defaults to true and it is highly recommended that you do not disable it. If this feature is disabled, it will allow a developer to use "Then" to invoke a non-Then step, causing the extension to spin a "Given" or a "When". Equally problematic, disabling this feature will allow a developer to use a "Given" or "When" to invoke a "Then", preventing the extension from spinning the "Then" step.