### PR TITLE
Fix Strict Keywords error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ default:
         Chekote\BehatRetryExtension:
           timeout: 10
           interval: 1000000000
-          strict-keywords: true
+          strictKeywords: true
 ```
 
 ## Configuration Options


### PR DESCRIPTION
The strictKeywords settings was incorrectly referenced in the README as strict-keywords.