### PR TITLE
Fix example interval results in PHP Warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ default:
     extensions:
         Chekote\BehatRetryExtension:
           timeout: 10
-          interval: 1000000000
+          interval: 999999999
           strictKeywords: true
 ```
 


### PR DESCRIPTION
Fixes #10

## Problem:
The interval mentioned in the README results in the following error:

PHP Warning:  time_nanosleep(): nanoseconds was not in the range 0 to 999 999 999 or seconds was negative in Psy Shell code on line 1

## Cause:
The example value is too high. 999999999 is the max.

## Fix:
Update the example to use the valid max.